### PR TITLE
Add support for a large-width image

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -120,6 +120,12 @@ html, body {
     margin-right: 10px;
 }
 
+.large-image {
+    margin-left: calc(-1 * ((50vw - 50%)));
+    max-width: 96vw;
+    transform: translateX(calc(50vw - 50%));
+}
+
 .footer {
     text-align: center;
     background: #3498db;


### PR DESCRIPTION
Unfortunately, I do not know how to apply classes to an element in Markdown. Googling has led me to finding that the project would need a different parser to do so. However, pure HTML is allowed in Markdown, so this solution works if written like <img class="large-image" src="./img/azeroth_screenshot.png">
